### PR TITLE
Define and use constants based on EF Core version, not dotnet one

### DIFF
--- a/EntityFrameworkCore.UseRowNumberForPaging/EntityFrameworkCore.UseRowNumberForPaging.csproj
+++ b/EntityFrameworkCore.UseRowNumberForPaging/EntityFrameworkCore.UseRowNumberForPaging.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-		<Version>0.7</Version>
 		<Authors>Rwing</Authors>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<RepositoryUrl>https://github.com/Rwing/EntityFrameworkCore.UseRowNumberForPaging</RepositoryUrl>
@@ -13,6 +12,18 @@
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<DebugType>embedded</DebugType>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<UseEfCore8>false</UseEfCore8>
+		<UseEfCore9>true</UseEfCore9>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(UseEfCore8)' == 'true'">
+		<DefineConstants>$(DefineConstants);USE_EF_CORE_8</DefineConstants>
+		<Version>0.8</Version>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(UseEfCore9)' == 'true'">
+		<DefineConstants>$(DefineConstants);USE_EF_CORE_9</DefineConstants>
+		<Version>0.9</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(TargetFramework) != 'net9.0'">
@@ -23,11 +34,11 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+	<ItemGroup Condition="'$(UseEfCore8)' == 'true'">
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+	<ItemGroup Condition="'$(UseEfCore9)' == 'true'">
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
 	</ItemGroup>

--- a/EntityFrameworkCore.UseRowNumberForPaging/Offset2RowNumberConvertVisitor.EfCore8.cs
+++ b/EntityFrameworkCore.UseRowNumberForPaging/Offset2RowNumberConvertVisitor.EfCore8.cs
@@ -1,4 +1,4 @@
-#if !NET9_0_OR_GREATER
+#if USE_EF_CORE_8
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EntityFrameworkCore.UseRowNumberForPaging/Offset2RowNumberConvertVisitor.EfCore9.cs
+++ b/EntityFrameworkCore.UseRowNumberForPaging/Offset2RowNumberConvertVisitor.EfCore9.cs
@@ -1,4 +1,4 @@
-#if NET9_0_OR_GREATER
+#if USE_EF_CORE_9
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/EntityFrameworkCore.UseRowNumberForPaging/SqlServer2008QueryTranslationPostprocessorFactory.cs
+++ b/EntityFrameworkCore.UseRowNumberForPaging/SqlServer2008QueryTranslationPostprocessorFactory.cs
@@ -17,9 +17,9 @@ namespace EntityFrameworkCore.UseRowNumberForPaging
             => new SqlServer2008QueryTranslationPostprocessor(
                 _dependencies,
                 _relationalDependencies,
-#if NET9_0_OR_GREATER
+#if USE_EF_CORE_9
                 (RelationalQueryCompilationContext)queryCompilationContext
-#else
+#elif USE_EF_CORE_8
                 queryCompilationContext
 #endif
             );
@@ -28,9 +28,9 @@ namespace EntityFrameworkCore.UseRowNumberForPaging
             public SqlServer2008QueryTranslationPostprocessor(
                 QueryTranslationPostprocessorDependencies dependencies,
                 RelationalQueryTranslationPostprocessorDependencies relationalDependencies,
-#if NET9_0_OR_GREATER
+#if USE_EF_CORE_9
                 RelationalQueryCompilationContext queryCompilationContext
-#else
+#elif USE_EF_CORE_8
                 QueryCompilationContext queryCompilationContext
 #endif
             )
@@ -40,9 +40,9 @@ namespace EntityFrameworkCore.UseRowNumberForPaging
             public override Expression Process(Expression query)
             {
                 query = base.Process(query);
-#if NET9_0_OR_GREATER
+#if USE_EF_CORE_9
                 query = new Offset2RowNumberConvertVisitor(query, RelationalDependencies.SqlExpressionFactory, RelationalQueryCompilationContext.SqlAliasManager).Visit(query);
-#else
+#elif USE_EF_CORE_8
                 query = new Offset2RowNumberConvertVisitor(query, RelationalDependencies.SqlExpressionFactory).Visit(query);
 #endif
                 return query;


### PR DESCRIPTION
EF Core 9 can be used with dotnet 8 (as we do in our projects). And I believe EF Core 8 is suitable for dotnet 9.

Current configuration leads to incorrect behaviour when `EntityFrameworkCore.UseRowNumberForPaging` is used with dotnet 8 and EF Core 9.

This PR introduces new properties and compilation constants. With them use can publish two version of the package: one for EF Core 8 and the other for EF Core 9.

According to [docs](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-pack) `-Properties UseEfCore8=false -Properties UseEfCore9=true` should do it. Just flip around boolean flags.

I also made `Version` property dependant on those flags, but it is just a suggestion.